### PR TITLE
Increase max update interval to 600 minutes

### DIFF
--- a/custom_components/evlinkha/config_flow.py
+++ b/custom_components/evlinkha/config_flow.py
@@ -142,6 +142,6 @@ class EVLinkHAOptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Required(
                     CONF_UPDATE_INTERVAL,
                     default=self.config_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=60))
+                ): vol.All(vol.Coerce(int), vol.Range(min=1, max=600))
             }),
         )


### PR DESCRIPTION
This PR would increase the update interval that a user can set to 600 minutes (10 hours), allowing them to use this integration even on a free API tier.

Resolves issue #13